### PR TITLE
build(ios): included path of files for formatting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,7 @@
+disabled_rules: # rule identifiers to exclude from running
+  - orphaned_doc_comment
+  - line_length
+  - identifier_name
+included: # paths to include during linting. `--path` is ignored if present.
+  - ios/Classes
+  

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,4 +1,0 @@
-disabled_rules: # rule identifiers to exclude from running
-  - orphaned_doc_comment
-  - line_length
-  - identifier_name


### PR DESCRIPTION
Included path `ios/Classes` for formatting of swift files.
