### PR TITLE
fix(characteristic): added missing isNotifying property

### DIFF
--- a/apidoc/Characteristic.yml
+++ b/apidoc/Characteristic.yml
@@ -44,3 +44,9 @@ properties:
     since: "1.0.0"
     type: Titanium.Buffer
     platforms: [iphone, ipad]
+
+  - name: isNotifying
+    summary: Whether the characteristic is currently notifying or not.
+    since: "1.0.0"
+    type: Boolean
+    platforms: [iphone, ipad]

--- a/apidoc/MutableCharacteristic.yml
+++ b/apidoc/MutableCharacteristic.yml
@@ -15,12 +15,6 @@ properties:
     since: "1.0.0"
     type: Modules.BLE.Central
 
-  - name: isNotifying
-    summary: Whether the characteristic is currently notifying or not.
-    since: "1.0.0"
-    type: Boolean
-    platforms: [iphone, ipad]
-
   - name: permissions
     summary: The permissions of the characteristic value. It is only present if this JavaScript object represents a mutable characteristic.
     since: "1.0.0"

--- a/ios/Classes/TiBLECharacteristicProxy.swift
+++ b/ios/Classes/TiBLECharacteristicProxy.swift
@@ -59,4 +59,9 @@ class TiBLECharacteristicProxy: TiProxy {
         return _characteristic
     }
 
+    @objc
+    func isNotifying() -> NSNumber {
+        return NSNumber(value: _characteristic.isNotifying)
+    }
+
 }

--- a/ios/Classes/TiBLEMutableCharacteristicProxy.swift
+++ b/ios/Classes/TiBLEMutableCharacteristicProxy.swift
@@ -35,13 +35,6 @@ class TiBLEMutableCharacteristicProxy: TiBLECharacteristicProxy {
     }
 
     @objc
-    func isNotifying() -> NSNumber? {
-        guard let _mutableCharacteristic = characteristic() as? CBMutableCharacteristic else {
-            return nil
-        }
-        return NSNumber(value: _mutableCharacteristic.isNotifying)
-    }
-    @objc
     func permissions() -> NSNumber? {
         guard let _mutableCharacteristic = characteristic() as? CBMutableCharacteristic else {
             return nil


### PR DESCRIPTION
https://jira.appcelerator.org/browse/MOD-2798

Since **isNotifying** is property of **CBCharacteristic**, it should be inside class **TiBLECharacteristicProxy**. And since we are sending instance of **TiBLECharacteristicProxy** with peripheral and not **TiBLEMutableCharacteristicProxy**, we need **isNotifying** property inside **TiBLECharacteristicProxy** class.