### PR TITLE
fix(android): null check for services

### DIFF
--- a/android/src/appcelerator/ble/TiBLEPeripheralProxy.java
+++ b/android/src/appcelerator/ble/TiBLEPeripheralProxy.java
@@ -54,6 +54,9 @@ public class TiBLEPeripheralProxy extends KrollProxy
 	@Kroll.getProperty
 	public TiBLEServiceProxy[] services()
 	{
+		if (services == null) {
+			return null;
+		}
 		TiBLEServiceProxy[] serviceProxies = new TiBLEServiceProxy[services.size()];
 		for (int i = 0; i < services.size(); i++) {
 			serviceProxies[i] = new TiBLEServiceProxy(services.get(i));


### PR DESCRIPTION
Crash because `services` in `services.size()` was null so `.size()` doesn't work.
Returning `null` made scanning work again